### PR TITLE
fix: 🐛 Empty list as default argument

### DIFF
--- a/polygraphpy/utils/get_vdw_volume.py
+++ b/polygraphpy/utils/get_vdw_volume.py
@@ -1,9 +1,9 @@
 from rdkit import Chem
 from rdkit.Chem import AllChem, rdMolDescriptors
 
-def get_vdw_volume(smiles_list: list = [], verbose: bool = False) -> list:
+def get_vdw_volume(smiles_list: list | None = None, *, verbose: bool = False) -> list:
 
-    if len(smiles_list) == 0:
+    if smiles_list is None:
         smiles_list = [
             "CCO",
             "c1ccccc1",


### PR DESCRIPTION
Hi @jgdu4rte, congrats for the work! It is amazing!

While skiming through the code, I noticed a minor, yet relevant, silent bug and took the liberty of issuing this PR.

The function does not seem to be used in the rest of the code. Nonetheless, I thought if it is in the codebase, it better work as expected. Hope it is ok.


The error is related to using empty lists as default arguments in python (dicts have the same ill-bhevaiour). Python sets them as global variables, and thus multiple calls to the function may reuse the same global list over and over.

See the links below for mor details:
* https://www.hackerone.com/blog/python-pitfalls-perils-using-lists-and-dicts-default-arguments
* https://stackoverflow.com/questions/18141652/python-function-with-default-list-argument 